### PR TITLE
Use start values for two dimensional pixels rather than start and end

### DIFF
--- a/cooler/contrib/higlass.py
+++ b/cooler/contrib/higlass.py
@@ -136,18 +136,18 @@ def get_data(f, zoom_level, start_pos_1, end_pos_1, start_pos_2, end_pos_2):
     pixels = c.matrix(as_pixels=True, max_chunk=np.inf)[i0:i1, j0:j1]
  
     if not len(pixels):
-        return pd.DataFrame(columns=['genome_start', 'genome_end', 'balanced'])
+        return pd.DataFrame(columns=['genome_start1', 'genome_start2', 'balanced'])
  
     bins = c.bins()[['chrom', 'start', 'end', 'weight']]
     pixels = annotate(pixels, bins)
 
-    pixels['genome_start'] = chrom_cum_lengths[pixels['chrom1']] + pixels['start1']
-    pixels['genome_end'] = chrom_cum_lengths[pixels['chrom2']] + pixels['end2']
+    pixels['genome_start1'] = chrom_cum_lengths[pixels['chrom1']] + pixels['start1']
+    pixels['genome_start2'] = chrom_cum_lengths[pixels['chrom2']] + pixels['start2']
     pixels['balanced'] = (
         pixels['count'] * pixels['weight1'] * pixels['weight2']
     )
  
-    return pixels[['genome_start', 'genome_end', 'balanced']]
+    return pixels[['genome_start1', 'genome_start2', 'balanced']]
  
  
 def get_info(file_path):

--- a/tests/test_contrib.py
+++ b/tests/test_contrib.py
@@ -1,0 +1,17 @@
+from __future__ import print_function
+
+import cooler.contrib.higlass as cch
+import h5py
+import os.path as op
+
+testdir = op.realpath(op.dirname(__file__))
+
+def test_data_retrieval():
+    data_file = op.join(testdir, 'data', 'dixon2012-h1hesc-hindiii-allreps-filtered.1000kb.multires.cool')
+    
+    f = h5py.File(data_file, 'r')
+    
+    data = cch.get_data(f, 0, 0, 3276799999, 0, 3276799999)
+
+    assert(data['genome_start1'].iloc[0] == 0.)
+    assert(data['genome_start2'].iloc[0] == 0.)


### PR DESCRIPTION
When displaying a heatmap, we want to render pixels starting from their starts, rather than the start of one and end of the other.