### PR TITLE
Recursive merge

### DIFF
--- a/cooler/cli/cload.py
+++ b/cooler/cli/cload.py
@@ -345,6 +345,13 @@ def pairix(bins, pairs_path, cool_path, metadata, assembly, nproc, zero_based, m
     help="Do not delete temporary files when finished.",
     type=bool,
     default=False)
+@click.option(
+    "--max-merge",
+    help="Maximum number of chunks to merge before invoking recursive merging",
+    type=int,
+    default=42, 
+    show_default=True)
+
 # @click.option(
 #     "--format", "-f",
 #     help="Preset data format.",
@@ -352,7 +359,7 @@ def pairix(bins, pairs_path, cool_path, metadata, assembly, nproc, zero_based, m
 # --sep
 def pairs(bins, pairs_path, cool_path, metadata, assembly, chunksize,
           zero_based, comment_char, symmetric_input, no_symmetric_storage,
-          field, temp_dir, no_delete_temp, **kwargs):
+          field, temp_dir, no_delete_temp, max_merge,  **kwargs):
     """
     Bin any text file or stream of pairs.
 
@@ -451,7 +458,8 @@ def pairs(bins, pairs_path, cool_path, metadata, assembly, chunksize,
         triucheck=False,
         dupcheck=False,
         ensure_sorted=False,
-        symmetric=use_symmetric_storage
+        symmetric=use_symmetric_storage, 
+        max_merge=max_merge, 
     )
 
 

--- a/cooler/cli/cload.py
+++ b/cooler/cli/cload.py
@@ -349,7 +349,7 @@ def pairix(bins, pairs_path, cool_path, metadata, assembly, nproc, zero_based, m
     "--max-merge",
     help="Maximum number of chunks to merge before invoking recursive merging",
     type=int,
-    default=42, 
+    default=200, 
     show_default=True)
 
 # @click.option(

--- a/cooler/io/creation.py
+++ b/cooler/io/creation.py
@@ -602,7 +602,7 @@ def create(cool_uri, bins, pixels, columns=None, dtypes=None, metadata=None,
 
 def create_from_unordered(cool_uri, bins, chunks, columns=None, dtypes=None,
                           mergebuf=int(20e6), delete_temp=True, temp_dir=None,
-                          multifile_merge=False, max_merge = 42, **kwargs):
+                          multifile_merge=False, max_merge = 200, **kwargs):
     """
     Create a Cooler in two passes via an external sort mechanism. In the first
     pass, a sequence of data chunks are processed and sorted in memory and saved

--- a/cooler/io/creation.py
+++ b/cooler/io/creation.py
@@ -602,7 +602,7 @@ def create(cool_uri, bins, pixels, columns=None, dtypes=None, metadata=None,
 
 def create_from_unordered(cool_uri, bins, chunks, columns=None, dtypes=None,
                           mergebuf=int(20e6), delete_temp=True, temp_dir=None,
-                          multifile_merge=False, max_merge = 200, **kwargs):
+                          max_merge = 200, **kwargs):
     """
     Create a Cooler in two passes via an external sort mechanism. In the first
     pass, a sequence of data chunks are processed and sorted in memory and saved


### PR DESCRIPTION
Default is to engage it at 200 chunks to keep memory under control. 

200 chunks at 1kb resolution - index will be 3M bins * 4 bytes per int32 * 200 chunks = 2.4GB. Plus the chunk storage (about 1-2GB) - this would limit the merge memory footprint to about 4GB. 

Recursive merge would kick in at after 2 billion lines in the pairs file. It does slow things down by negligible factor - maybe 10% at 1kb resolution, but may actually be faster at low resolution. 