### PR TITLE
Make default tmpdir local and make rename_chroms refresh

### DIFF
--- a/cooler/api.py
+++ b/cooler/api.py
@@ -71,7 +71,9 @@ class Cooler(object):
             self.uri = self.filename + '::' + self.root
             self.store = store.file
             self.open_kws = {}
+        self._refresh()
 
+    def _refresh(self):
         try:
             with open_hdf5(self.store, **self.open_kws) as h5:
                 grp = h5[self.root]

--- a/cooler/cli/cload.py
+++ b/cooler/cli/cload.py
@@ -318,8 +318,9 @@ def pairix(bins, pairs_path, cool_path, metadata, assembly, nproc, zero_based, m
 #     default=False)
 @click.option(
     "--temp-dir",
-    help="Create temporary files in specified directory.",
-    type=str)
+    help="Create temporary files in a specified directory. Pass ``-`` to use "
+         "the platform default temp dir.",
+    type=click.Path(exists=True, file_okay=False, dir_okay=True, allow_dash=True))
 @click.option(
     "--no-delete-temp",
     help="Do not delete temporary files when finished.",

--- a/cooler/create/_create.py
+++ b/cooler/create/_create.py
@@ -625,6 +625,8 @@ def create_from_unordered(cool_uri, bins, chunks, columns=None, dtypes=None,
 
     if temp_dir is None:
         temp_dir = op.dirname(parse_cooler_uri(cool_uri)[0])
+    elif temp_dir == '-':
+        temp_dir = None  # makes tempfile module use the system dir
 
     dtypes = _get_dtypes_arg(dtypes, kwargs)
 
@@ -854,8 +856,8 @@ def create_cooler(cool_uri, bins, pixels, columns=None, dtypes=None,
         Whether to delete temporary files when finished.
         Useful for debugging. Default is False.
     temp_dir : str, optional
-        Create temporary files in a specified directory instead of the
-        same directory as the output file.
+        Create temporary files in a specified directory instead of the same
+        directory as the output file. Pass ``-`` to use the system default.
     max_merge : int, optional
         If merging more than ``max_merge`` chunks, do the merge recursively in
         two passes.

--- a/cooler/create/_create.py
+++ b/cooler/create/_create.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, print_function, division
 from datetime import datetime
 from six.moves import map
 from pandas.api.types import is_categorical, is_integer
+import os.path as op
 import pandas as pd
 import numpy as np
 import posixpath
@@ -622,6 +623,9 @@ def create_from_unordered(cool_uri, bins, chunks, columns=None, dtypes=None,
     if columns is not None:
         columns = [col for col in columns if col not in {'bin1_id', 'bin2_id'}]
 
+    if temp_dir is None:
+        temp_dir = op.dirname(parse_cooler_uri(cool_uri)[0])
+
     dtypes = _get_dtypes_arg(dtypes, kwargs)
 
     temp_files = []
@@ -850,8 +854,8 @@ def create_cooler(cool_uri, bins, pixels, columns=None, dtypes=None,
         Whether to delete temporary files when finished.
         Useful for debugging. Default is False.
     temp_dir : str, optional
-        Create temporary files in the specified directory instead of the
-        system one.
+        Create temporary files in a specified directory instead of the
+        same directory as the output file.
     max_merge : int, optional
         If merging more than ``max_merge`` chunks, do the merge recursively in
         two passes.

--- a/cooler/create/_create.py
+++ b/cooler/create/_create.py
@@ -365,7 +365,8 @@ def _rename_chroms(grp, rename_dict, h5opts):
 
 def rename_chroms(clr, rename_dict, h5opts=None):
     """
-    Substitute existing scaffold names for new ones.
+    Substitute existing chromosome/contig names for new ones. They will be
+    written to the file and the Cooler object will be refreshed.
 
     Parameters
     ----------
@@ -382,6 +383,7 @@ def rename_chroms(clr, rename_dict, h5opts=None):
 
     with clr.open('r+') as f:
         _rename_chroms(f, rename_dict, h5opts)
+    clr._refresh()
 
 
 def _get_dtypes_arg(dtypes, kwargs):

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -120,8 +120,7 @@ def test_rename_chroms():
         clr = cooler.Cooler('toy.asymm.4.cool')
         assert clr.chromnames == ['chr1', 'chr2']
         cooler.rename_chroms(clr, {'chr1': '1', 'chr2': '2'})
-        clr = cooler.Cooler('toy.asymm.4.cool')
-        assert clr.chromnames == ['1', '2']
+        assert clr.chromnames == ['1', '2']  # the Cooler object is refreshed
 
 
 def test_create_custom_cols():

--- a/tests/test_creation_ingest.py
+++ b/tests/test_creation_ingest.py
@@ -4,6 +4,7 @@ import os.path as op
 import tempfile
 import filecmp
 import os
+from pandas.api import types
 import numpy as np
 import pandas as pd
 import h5py
@@ -282,7 +283,6 @@ def test_cload_field(bins_path, pairs_path):
         chrom1=1, pos1=2,
         chrom2=3, pos2=4,
     )
-    from pandas.api import types
     cload_pairs.callback(
         bins_path,
         pairs_path,
@@ -295,36 +295,34 @@ def test_cload_field(bins_path, pairs_path):
     assert 'score' in pixels.columns and types.is_float_dtype(pixels.dtypes['score'])
 
 
-# @pytest.mark.parametrize("bins_path,pairs_path", [(
-#     op.join(testdir, 'data', 'toy.chrom.sizes') + ':2',
-#     op.join(testdir, 'data', 'toy.pairs')
-# )])
-# def test_cload_field2(bins_path, pairs_path):
-#     from pandas.api import types
-
-#     cload_pairs.callback(
-#         bins_path,
-#         pairs_path,
-#         testcool_path,
-#         metadata=None,
-#         assembly='toy',
-#         chunksize=10,
-#         zero_based=False,
-#         comment_char='#',
-#         input_copy_status='unique',
-#         no_symmetric_upper=False,
-#         field=('count=7:agg=min,dtype=float',),
-#         temp_dir=None,
-#         no_delete_temp=False,
-#         storage_options=None,
-#         no_count=True,
-#         max_merge=200,
-#         chrom1=1, pos1=2,
-#         chrom2=3, pos2=4,
-#     )
-#     pixels = cooler.Cooler(testcool_path).pixels()[:]
-#     assert 'count' in pixels.columns and types.is_float_dtype(pixels.dtypes['count'])
-#     assert np.allclose(pixels['count'][:], 0.1)
+@pytest.mark.parametrize("bins_path,pairs_path", [(
+    op.join(testdir, 'data', 'toy.chrom.sizes') + ':2',
+    op.join(testdir, 'data', 'toy.pairs')
+)])
+def test_cload_custom_tempdir(bins_path, pairs_path):
+    for temp_dir in [op.join(testdir, 'data'), '-']:
+        cload_pairs.callback(
+            bins_path,
+            pairs_path,
+            testcool_path,
+            metadata=None,
+            assembly='toy',
+            chunksize=10,
+            zero_based=False,
+            comment_char='#',
+            input_copy_status='unique',
+            no_symmetric_upper=False,
+            field=(),
+            temp_dir=temp_dir,
+            no_delete_temp=False,
+            storage_options=None,
+            no_count=True,
+            max_merge=200,
+            chrom1=1, pos1=2,
+            chrom2=3, pos2=4,
+        )
+        pixels = cooler.Cooler(testcool_path).pixels()[:]
+        assert 'count' in pixels.columns and types.is_integer_dtype(pixels.dtypes['count'])
 
 
 def test_load_bg2_vs_coo():


### PR DESCRIPTION
* When assembling a cooler from unordered input, the temporary coolers will be stored in a file in the same location as the final output file #150 
* `rename_chroms` will refresh the cached metadata of the Cooler object to reflect the renaming #147 