### PR TITLE
Replace json with simplejson to cover bytes vs strings issue

### DIFF
--- a/cooler/api.py
+++ b/cooler/api.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function
-import json
+import simplejson as json
 import six
 import os
 

--- a/cooler/cli/cload.py
+++ b/cooler/cli/cload.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function
 from multiprocess import Pool
-import json
+import simplejson as json
 import six
 import sys
 

--- a/cooler/cli/info.py
+++ b/cooler/cli/info.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import division, print_function
-import json
+import simplejson as json
 import sys
 
 from ._util import exit_on_broken_pipe
@@ -47,7 +47,6 @@ def info(cool_uri, field, metadata, out):
         f = sys.stdout
     else:
         f = open(out, "wt")
-
     if metadata:
         json.dump(c.info["metadata"], f, indent=4)
         print(end="\n", file=f)

--- a/cooler/cli/load.py
+++ b/cooler/cli/load.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function
-import json
+import simplejson as json
 import sys
 
 import numpy as np

--- a/cooler/create/_create.py
+++ b/cooler/create/_create.py
@@ -10,7 +10,7 @@ import posixpath
 import tempfile
 import warnings
 import h5py
-import json
+import simplejson as json
 import six
 
 from .._version import __version__, __format_version__

--- a/cooler/fileops.py
+++ b/cooler/fileops.py
@@ -4,14 +4,15 @@ from datetime import datetime
 from textwrap import dedent
 import warnings
 import uuid
-import json
+import simplejson as json
+
 import os
 
 from six import PY2
 import six
 
 try:
-    from json import JSONDecodeError
+    from simplejson import JSONDecodeError
 except ImportError:
     JSONDecodeError = ValueError  # PY35+
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pyfaidx
 pypairix
 asciitree
 pyyaml
+simplejson

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,7 +11,8 @@ from io import StringIO
 from glob import glob
 import os.path as op
 import tempfile
-import json
+import simplejson as json
+
 
 from pandas.api import types
 import numpy as np


### PR DESCRIPTION
Hi Nezar,

Users of my HiCExplorer are having the issue that created cool files by HiCExplorer are crashing if they are investigated with e.g. cool info, see for example https://github.com/deeptools/HiCExplorer/issues/468. The reason is quite simple, I store my data as bytes and not explicitly encoded as utf-8 and this leads to a crash with the json library. 

I propose the following simple fix: Replace all imports of json with simplejson, a library which takes care of such issues. I tested it and all your test cases are passing. 

Best,

Joachim