### PR TITLE
Make pysam an optional dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
   - conda info -a
 
   # Create test environment and install deps
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION setuptools pip six numpy scipy pandas h5py dask
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION setuptools pip six numpy scipy pandas h5py dask pysam
   - source activate test-environment
   - pip install mock pytest pytest-flake8 pytest-cov codecov
   - pip install -e .

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
   - conda info -a
 
   # Create test environment and install deps
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION setuptools pip six numpy scipy pandas h5py dask pysam
+  - conda create -c bioconda -q -n test-environment python=$TRAVIS_PYTHON_VERSION setuptools pip six numpy scipy pandas h5py dask pysam
   - source activate test-environment
   - pip install mock pytest pytest-flake8 pytest-cov codecov
   - pip install -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ scipy>=0.16
 pandas>=0.19
 h5py>=2.5
 click>=7
-pysam>0.8
 cytoolz
 multiprocess
 biopython

--- a/setup.py
+++ b/setup.py
@@ -58,12 +58,12 @@ tests_require = [
     'mock'
 ]
 
-
 extras_require = {
     'docs': [
         'Sphinx>=1.1',
         'numpydoc>=0.5'
-    ]
+    ],
+    'pysam': ['pysam']
 }
 
 


### PR DESCRIPTION
As discussed in #187, this pull request makes pysam optional. By:
* Removing pysam from the `requirements.txt` file
* Adding pysam to the `extras_require` in `setup.py`

Programs using cooler and pysam as dependencies will have to explicitely require pysam `cooler[pysam]`, otherwise only cooler is installed.