### PR TITLE
fixed deprecation warnings in numpy and h5py

### DIFF
--- a/cooler/fileops.py
+++ b/cooler/fileops.py
@@ -406,7 +406,7 @@ def pprint_data_tree(uri, level):
 
 def _decode_attr_value(obj):
     if hasattr(obj, "item"):
-        o = np.asscalar(obj)
+        o = obj.item()
     elif hasattr(obj, "tolist"):
         o = obj.tolist()
     elif isinstance(obj, six.string_types):

--- a/cooler/util.py
+++ b/cooler/util.py
@@ -619,7 +619,7 @@ def attrs_to_jsonable(attrs):
     out = dict(attrs)
     for k, v in attrs.items():
         try:
-            out[k] = np.asscalar(v)
+            out[k] = v.item()
         except ValueError:
             out[k] = v.tolist()
         except AttributeError:

--- a/tests/test_fileops.py
+++ b/tests/test_fileops.py
@@ -38,7 +38,7 @@ def test_cp():
         shutil.copyfile(src_file, test_file)
         fileops.cp(test_file + "::resolutions/2", test_file + "::abc/d")
         cooler_cmp(test_file + "::resolutions/2", test_file + "::abc/d")
-        with h5py.File(test_file) as f:
+        with h5py.File(test_file, mode='r') as f:
             assert "resolutions/2" in f
             assert "abc/d" in f
             assert f["resolutions/2"].id != f["abc/d"].id
@@ -51,7 +51,7 @@ def test_mv():
         shutil.copyfile(op.join(testdir, "data", "toy.symm.upper.2.mcool"), ref_file)
         shutil.copyfile(op.join(testdir, "data", "toy.symm.upper.2.mcool"), src_file)
         fileops.mv(src_file + "::resolutions/2", src_file + "::abc/d")
-        with h5py.File(src_file) as f:
+        with h5py.File(src_file, mode='r') as f:
             assert "resolutions/2" not in f
             assert "abc/d" in f
         cooler_cmp(ref_file + "::resolutions/2", src_file + "::abc/d")
@@ -65,7 +65,7 @@ def test_ln():
         test_file = "test.hardlink.mcool"
         shutil.copyfile(src_file, test_file)
         fileops.ln(test_file + "::resolutions/2", test_file + "::abc/d")
-        with h5py.File(test_file) as f:
+        with h5py.File(test_file, mode='r') as f:
             assert "resolutions/2" in f
             assert "abc/d" in f
             assert f["resolutions/2"].id == f["abc/d"].id
@@ -75,7 +75,7 @@ def test_ln():
         test_file = "test.softlink.mcool"
         shutil.copyfile(src_file, test_file)
         fileops.ln(test_file + "::resolutions/2", test_file + "::abc/d", soft=True)
-        with h5py.File(test_file) as f:
+        with h5py.File(test_file, mode='r') as f:
             assert "resolutions/2" in f
             assert "abc/d" in f
             assert f["resolutions/2"].id == f["abc/d"].id


### PR DESCRIPTION
h5py ones are harmless, but suppressing them will get rid of the warnings. 