### PR TITLE
Customizable zoom progressions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ python:
   - "3.7"
   - "3.8"
 install:
-  # http://conda.pydata.org/docs/travis.html
   - sudo apt-get update
   - sudo apt-get install -y pigz tabix
+
   # We do this conditionally because it saves us some downloading if the version is the same.
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
       wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
@@ -20,14 +20,15 @@ install:
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
+
   # Useful for debugging any issues with conda
   - conda info -a
 
   # Create test environment and install deps
-  - conda create -c bioconda -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy cython h5py
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy cython h5py
   - source activate test-environment
-  - pip install six scipy pandas pysam dask[array,dataframe]
-  - pip install psutil ipytree matplotlib
+  - pip install six scipy pandas dask[array,dataframe]
+  - pip install pysam psutil ipytree matplotlib
   - pip install mock pytest pytest-flake8 pytest-cov codecov
   - pip install -e .
 

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 <a href="https://mirnylab.github.io/cooler"><img width="25%" src="https://github.com/mirnylab/cooler/raw/master/docs/cooler_logo.png" alt="Cooler"></a>
 
 [![Build Status](https://travis-ci.org/mirnylab/cooler.svg?branch=master)](https://travis-ci.org/mirnylab/cooler)
+[![CodeCov](https://codecov.io/gh/mirnylab/cooler/branch/master/graph/badge.svg)](https://codecov.io/gh/mirnylab/cooler)
 [![Documentation Status](https://readthedocs.org/projects/cooler/badge/?version=latest)](http://cooler.readthedocs.org/en/latest/)
 [![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat-square)](http://bioconda.github.io/recipes/cooler/README.html)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/mirnylab/cooler-binder/master)
 [![Join the chat at https://gitter.im/mirnylab/cooler](https://badges.gitter.im/mirnylab/cooler.svg)](https://gitter.im/mirnylab/cooler?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![DOI](https://zenodo.org/badge/49553222.svg)](https://zenodo.org/badge/latestdoi/49553222)
-[![CodeCov](https://codecov.io/gh/mirnylab/cooler/branch/master/graph/badge.svg)](https://codecov.io/gh/mirnylab/cooler)
 
 ## A cool place to store your Hi-C
 

--- a/cooler/cli/zoomify.py
+++ b/cooler/cli/zoomify.py
@@ -73,7 +73,12 @@ def invoke_balance(args, resolutions, outfile):
 )
 @click.option(
     "--resolutions", "-r",
-    help="Comma-separated list of target resolutions."
+    help="Comma-separated list of target resolutions. Use suffixes B or N to "
+    "specify a progression: B for binary (geometric steps of factor 2), N for "
+    "nice (geometric steps of factor 10 interleaved with steps of 2 and 5). "
+    "Examples: 1000B=1000,2000,4000,8000,... 1000N=1000,2000,5000,10000,... "
+    "5000N=5000,10000,25000,50000,... 4DN is an alias for 1000,2000,5000N "
+    "[default: B]"
 )
 @click.option(
     "--balance",

--- a/cooler/reduce.py
+++ b/cooler/reduce.py
@@ -342,6 +342,97 @@ def get_quadtree_depth(chromsizes, base_binsize, bins_per_tile):
     return n_zoom_levels
 
 
+def geomprog(start, mul):
+    """
+    Generate a geometric progression of integers.
+
+    Beginning with integer ``start``, yield an unbounded geometric progression
+    with integer ratio ``mul``.
+
+    """
+    start, mul = int(start), int(mul)
+    yield start
+    while True:
+        start *= mul
+        yield start
+
+
+def niceprog(start):
+    """
+    Generate a nice progression of integers.
+
+    Beginning with integer ``start``, yield a sequence of "nicely" spaced
+    integers: an unbounded geometric progression with ratio 10, interspersed
+    with steps of ratios 2 and 5.
+
+    """
+    start = int(start)
+    yield start
+    while True:
+        for mul in (2, 5, 10):
+            yield start * mul
+        start *= 10
+
+
+def preferred_sequence(start, stop, style='nice'):
+    """
+    Return a sequence of integers with a "preferred" stepping pattern.
+
+    Parameters
+    ----------
+    start : int
+        Starting value in the progression.
+    stop : int
+        Upper bound of progression, inclusive. Values will not exceed this.
+    style : {'nice', 'binary'}
+        Style of progression. 'nice' gives geometric steps of 10 with 2 and 5
+        in between. 'binary' gives geometric steps of 2.
+
+    Returns
+    ------
+    list of int
+
+    Examples
+    --------
+    For certain values of `start` (n * 10^i), nice stepping produces familiar
+    "preferred" sequences [1]_:
+
+    Note denominations in Dollars (1-2-5)
+
+        >>> preferred_sequence(1, 100, 'nice')
+        [1, 2, 5, 10, 20, 50, 100]
+
+
+    Coin denominations in Cents
+
+        >>> preferred_sequence(5, 100, 'nice')
+        [5, 10, 25, 50, 100]
+
+    .. [1] https://en.wikipedia.org/wiki/Preferred_number#1-2-5_series
+
+    """
+    if start > stop:
+        return []
+
+    if style == 'binary':
+        gen = geomprog(start, 2)
+    elif style == 'nice':
+        gen = niceprog(start)
+    else:
+        ValueError(
+            "Expected style value of 'binary' or 'nice'; got '{}'.".format(style)
+        )
+
+    seq = [next(gen)]
+    while True:
+        n = next(gen)
+        if n > stop:
+            break
+        seq.append(n)
+
+    return seq
+
+
 def get_multiplier_sequence(resolutions, bases=None):
     """
     From a set of target resolutions and one or more base resolutions

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ h5py>=2.5
 click>=7
 cytoolz
 multiprocess
-biopython
+biopython<1.77
 pyfaidx
 pypairix
 asciitree


### PR DESCRIPTION
A way to succinctly specify certain resolution patterns for zoomification on the command line.

`B` : binary geometric progression: zooms increase by factors of 2.
`N`: preferred/nice progression similar to https://en.wikipedia.org/wiki/Preferred_number#1-2-5_series but based on steps of factor 10 interleaved with steps of 2 and 5.

Progressions increase until reaching a resolution of genome length in bp / 256.

Examples:

* `1000N` expands to the 1-2-5 series: `[1000, 2000, 5000, 10000, 20000, ...]`
* `5000N` expands to the 10-25-50 series: `[5000, 10000, 25000, 50000, 100000, ...]`
* The standard 4DN resolutions are summarized as `1000,2000,5000N` which expands to `[1000, 2000, 5000, 10000, 25000, 50000, 100000, 250000, ...]`


