### PR TITLE
Fix get_header to work with different peek implementations

### DIFF
--- a/cooler/cli/cload.py
+++ b/cooler/cli/cload.py
@@ -49,17 +49,28 @@ def get_header(instream, comment_char='#'):
         raise ValueError('Please, provide a comment char!')
     comment_byte = comment_char.encode()
     # get peekable buffer for the instream
-    inbuffer = instream.buffer
-    current_peek = inbuffer.peek()
+    read_f, peek_f = None, None
+    if hasattr(instream, 'buffer'):
+        peek_f = instream.buffer.peek
+        readline_f = instream.buffer.readline
+    elif hasattr(instream, 'peek'):
+        peek_f = instream.peek
+        readline_f = instream.readline
+    else:
+        raise ValueError('Cannot find the peek() function of the provided stream!')
+        
+    current_peek = peek_f(1)
     while current_peek.startswith(comment_byte):
         # consuming a line from buffer guarantees
-        # that the remainder of the buffer starts
+        # that the remainder of the buffer starts 
         # with the beginning of the line.
-        line = inbuffer.readline()
+        line = readline_f()
+        if isinstance(line, bytes):
+            line = line.decode()
         # append line to header, since it does start with header
-        header.append(line.decode().strip())
+        header.append(line.strip())
         # peek into the remainder of the instream
-        current_peek = inbuffer.peek()
+        current_peek = peek_f(1)
     # apparently, next line does not start with the comment
     # return header and the instream, advanced to the beginning of the data
     return header, instream


### PR DESCRIPTION
From https://github.com/open2c/pairtools/commit/de185f032ff2e1af311668c523520bec5065084e (@golobor)